### PR TITLE
add the ca_path to the connection http object

### DIFF
--- a/lib/active_utils/common/connection.rb
+++ b/lib/active_utils/common/connection.rb
@@ -105,6 +105,7 @@ module ActiveMerchant
 
       if verify_peer
         http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        http.ca_path     = '/etc/ssl/certs'
         http.ca_file     = File.dirname(__FILE__) + '/../../certs/cacert.pem'
       else
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE


### PR DESCRIPTION
This will remove the `OpenSSL::SSL::SSLError (SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed)` error that can occour when the http object can't find the Certificate Authority in the `/lib/certs/cacert.pem` file.
