### PR TITLE
Make the ca_file configurable

### DIFF
--- a/lib/active_utils/common/connection.rb
+++ b/lib/active_utils/common/connection.rb
@@ -9,6 +9,8 @@ module ActiveMerchant
     OPEN_TIMEOUT = 60
     READ_TIMEOUT = 60
     VERIFY_PEER = true
+    CA_FILE = (File.dirname(__FILE__) + '/../../certs/cacert.pem')
+    CA_PATH = nil
     RETRY_SAFE = false
     RUBY_184_POST_HEADERS = { "Content-Type" => "application/x-www-form-urlencoded" }
 
@@ -16,6 +18,8 @@ module ActiveMerchant
     attr_accessor :open_timeout
     attr_accessor :read_timeout
     attr_accessor :verify_peer
+    attr_accessor :ca_file
+    attr_accessor :ca_path
     attr_accessor :retry_safe
     attr_accessor :pem
     attr_accessor :pem_password
@@ -30,6 +34,8 @@ module ActiveMerchant
       @read_timeout = READ_TIMEOUT
       @retry_safe   = RETRY_SAFE
       @verify_peer  = VERIFY_PEER
+      @ca_file      = CA_FILE
+      @ca_path      = CA_PATH
       @ignore_http_status = false
     end
 
@@ -106,7 +112,8 @@ module ActiveMerchant
 
       if verify_peer
         http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-        http.ca_file     = File.dirname(__FILE__) + '/../../certs/cacert.pem'
+        http.ca_file     = ca_file
+        http.ca_path     = ca_path
       else
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE
       end

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -88,6 +88,28 @@ class ConnectionTest < Test::Unit::TestCase
     assert_equal false, @connection.verify_peer
   end
 
+  def test_default_ca_file
+    assert_equal ActiveMerchant::Connection::CA_FILE, @connection.ca_file
+    assert_equal ActiveMerchant::Connection::CA_FILE, @connection.send(:http).ca_file
+  end
+
+  def test_override_ca_file
+    @connection.ca_file = "/bogus"
+    assert_equal "/bogus", @connection.ca_file
+    assert_equal "/bogus", @connection.send(:http).ca_file
+  end
+
+  def test_default_ca_path
+    assert_equal ActiveMerchant::Connection::CA_PATH, @connection.ca_path
+    assert_equal ActiveMerchant::Connection::CA_PATH, @connection.send(:http).ca_path
+  end
+
+  def test_override_ca_path
+    @connection.ca_path = "/bogus"
+    assert_equal "/bogus", @connection.ca_path
+    assert_equal "/bogus", @connection.send(:http).ca_path
+  end
+
   def test_unrecoverable_exception
     @connection.logger.expects(:error).once
     Net::HTTP.any_instance.expects(:post).raises(EOFError)


### PR DESCRIPTION
While it's handy to include a default cacert.pem with the library, some
customers will need to use their own. This makes `ca_file` a configurable
value on `Connection`.
