### PR TITLE
Refactor network retry logic into a reusable module

### DIFF
--- a/lib/active_utils.rb
+++ b/lib/active_utils.rb
@@ -3,6 +3,7 @@ require 'active_support/core_ext/hash/conversions'
 require 'active_support/core_ext/class/attribute'
 
 module ActiveMerchant
+  autoload :NetworkConnectionRetries,  'active_utils/common/network_connection_retries'
   autoload :Connection,                'active_utils/common/connection'
   autoload :Country,                   'active_utils/common/country'
   autoload :CountryCode,               'active_utils/common/country'

--- a/lib/active_utils/common/network_connection_retries.rb
+++ b/lib/active_utils/common/network_connection_retries.rb
@@ -1,0 +1,58 @@
+module ActiveMerchant
+  module NetworkConnectionRetries
+    DEFAULT_RETRIES = 3
+    DEFAULT_CONNECTION_ERRORS = {
+      EOFError          => "The remote server dropped the connection",
+      Errno::ECONNRESET => "The remote server reset the connection",
+      Timeout::Error    => "The connection to the remote server timed out",
+      Errno::ETIMEDOUT  => "The connection to the remote server timed out"
+    }
+
+    def self.included(base)
+      base.send(:attr_accessor, :retry_safe)
+    end
+
+    def retry_exceptions(options={})
+      connection_errors = DEFAULT_CONNECTION_ERRORS.merge(options[:connection_exceptions] || {})
+
+      retry_network_exceptions(options) do
+        begin
+          yield
+        rescue Errno::ECONNREFUSED => e
+          raise ActiveMerchant::RetriableConnectionError, "The remote server refused the connection"
+        rescue OpenSSL::X509::CertificateError => e
+          NetworkConnectionRetries.log(options[:logger], :error, e.message, options[:tag])
+          raise ActiveMerchant::ClientCertificateError, "The remote server did not accept the provided SSL certificate"
+        rescue *connection_errors.keys => e
+          raise ActiveMerchant::ConnectionError, connection_errors[e.class]
+        end
+      end
+    end
+
+    private
+
+    def retry_network_exceptions(options = {})
+      retries = options[:max] || DEFAULT_RETRIES
+
+      begin
+        yield
+      rescue ActiveMerchant::RetriableConnectionError => e
+        retries -= 1
+        retry unless retries.zero?
+        NetworkConnectionRetries.log(options[:logger], :error, e.message, options[:tag])
+        raise ActiveMerchant::ConnectionError, e.message
+      rescue ActiveMerchant::ConnectionError => e
+        retries -= 1
+        retry if (options[:retry_safe] || retry_safe) && !retries.zero?
+        NetworkConnectionRetries.log(options[:logger], :error, e.message, options[:tag])
+        raise
+      end
+    end
+
+    def self.log(logger, level, message, tag=nil)
+      tag ||= self.class.to_s
+      message = "[#{tag}] #{message}"
+      logger.send(level, message) if logger
+    end
+  end
+end

--- a/test/unit/network_connection_retries_test.rb
+++ b/test/unit/network_connection_retries_test.rb
@@ -1,0 +1,127 @@
+require 'test_helper'
+require 'openssl'
+require 'net/http'
+
+class NetworkConnectionRetriesTest < Test::Unit::TestCase
+  class MyNewError < StandardError
+  end
+
+  include NetworkConnectionRetries
+
+  def setup
+    @logger = stubs(:logger)
+    @requester = stubs(:requester)
+    @ok = stub(:code => 200, :message => 'OK', :body => 'success')
+  end
+
+  def test_unrecoverable_exception
+    assert_raises(ActiveMerchant::ConnectionError) do
+      retry_exceptions do
+        raise EOFError
+      end
+    end
+  end
+
+  def test_unrecoverable_exception_logged_if_logger_provided
+    @logger.expects(:error).once
+    assert_raises(ActiveMerchant::ConnectionError) do
+      retry_exceptions :logger => @logger do
+        raise EOFError
+      end
+    end
+  end
+
+  def test_failure_then_success_with_recoverable_exception
+    @requester.expects(:post).times(2).raises(Errno::ECONNREFUSED).then.returns(@ok)
+
+    assert_nothing_raised do
+      retry_exceptions do
+        @requester.post
+      end
+    end
+  end
+
+  def test_failure_limit_reached
+    @requester.expects(:post).times(ActiveMerchant::NetworkConnectionRetries::DEFAULT_RETRIES).raises(Errno::ECONNREFUSED)
+
+    assert_raises(ActiveMerchant::ConnectionError) do
+      retry_exceptions do
+        @requester.post
+      end
+    end
+  end
+
+  def test_failure_limit_reached_logs_final_error
+    @logger.expects(:error).once
+    @requester.expects(:post).times(ActiveMerchant::NetworkConnectionRetries::DEFAULT_RETRIES).raises(Errno::ECONNREFUSED)
+
+    assert_raises(ActiveMerchant::ConnectionError) do
+      retry_exceptions(:logger => @logger) do
+        @requester.post
+      end
+    end
+  end
+
+  def test_failure_then_success_with_retry_safe_enabled
+    @requester.expects(:post).times(2).raises(EOFError).then.returns(@ok)
+
+    assert_nothing_raised do
+      retry_exceptions :retry_safe => true do
+        @requester.post
+      end
+    end
+  end
+
+  def test_mixture_of_failures_with_retry_safe_enabled
+    @requester.expects(:post).times(3).raises(Errno::ECONNRESET).
+                                       raises(Errno::ECONNREFUSED).
+                                       raises(EOFError)
+
+    assert_raises(ActiveMerchant::ConnectionError) do
+      retry_exceptions :retry_safe => true do
+        @requester.post
+      end
+    end
+  end
+
+  def test_failure_with_ssl_certificate
+    @requester.expects(:post).raises(OpenSSL::X509::CertificateError)
+
+    assert_raises(ActiveMerchant::ClientCertificateError) do
+      retry_exceptions do
+        @requester.post
+      end
+    end
+  end
+
+  def test_failure_with_ssl_certificate_logs_error_if_logger_specified
+    @logger.expects(:error).once
+    @requester.expects(:post).raises(OpenSSL::X509::CertificateError)
+
+    assert_raises(ActiveMerchant::ClientCertificateError) do
+      retry_exceptions :logger => @logger do
+        @requester.post
+      end
+    end
+  end
+
+  def test_failure_with_additional_exceptions_specified
+    @requester.expects(:post).raises(MyNewError)
+
+    assert_raises(ActiveMerchant::ConnectionError) do
+      retry_exceptions :connection_exceptions => {MyNewError => "my message"} do
+        @requester.post
+      end
+    end
+  end
+
+  def test_failure_without_additional_exceptions_specified
+    @requester.expects(:post).raises(MyNewError)
+
+    assert_raises(MyNewError) do
+      retry_exceptions do
+        @requester.post
+      end
+    end
+  end
+end


### PR DESCRIPTION
We've been using this in a few other projects outside of the connection object so time to refactor into something reusable.

@odorcicd and @Soleone for review.
