### PR TITLE
Fix ActiveSupport 2.3.x compatibility

### DIFF
--- a/lib/active_utils.rb
+++ b/lib/active_utils.rb
@@ -1,6 +1,8 @@
 require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/core_ext/hash/conversions'
 require 'active_support/core_ext/class/attribute'
+require 'active_support/core_ext/object/blank'
+require 'active_support/inflector'
 
 module ActiveMerchant
   autoload :NetworkConnectionRetries,  'active_utils/common/network_connection_retries'


### PR DESCRIPTION
The 2.3 branch of ActiveSupport is not very good about requiring all
necessary dependencies, so the tests were failing when run against 2.3.
