### PR TITLE
Wrap Zlib::BufError in ActiveMerchant::InvalidResponseError

### DIFF
--- a/lib/active_utils/common/error.rb
+++ b/lib/active_utils/common/error.rb
@@ -23,4 +23,7 @@ module ActiveMerchant #:nodoc:
 
   class ClientCertificateError < ActiveMerchantError # :nodoc
   end
+
+  class InvalidResponseError < ActiveMerchantError # :nodoc
+  end
 end

--- a/test/unit/network_connection_retries_test.rb
+++ b/test/unit/network_connection_retries_test.rb
@@ -22,6 +22,14 @@ class NetworkConnectionRetriesTest < Test::Unit::TestCase
     end
   end
 
+  def test_invalid_response_error
+    assert_raises(ActiveMerchant::InvalidResponseError) do
+      retry_exceptions do
+        raise Zlib::BufError
+      end
+    end
+  end
+
   def test_unrecoverable_exception_logged_if_logger_provided
     @logger.expects(:info).once
     assert_raises(ActiveMerchant::ConnectionError) do


### PR DESCRIPTION
This wraps `Zlib::BufError` into a more friendly `ActiveMerchantError`. This will now be retriable and rescuable at a higher level.

Ref.: https://github.com/Shopify/shopify/issues/12353

@jduff @costford for review

Paired with @gmalette 
