### PR TITLE
Add OpenSSL::SSL::SSLError as a connection error class

### DIFF
--- a/lib/active_utils/common/network_connection_retries.rb
+++ b/lib/active_utils/common/network_connection_retries.rb
@@ -2,10 +2,11 @@ module ActiveMerchant
   module NetworkConnectionRetries
     DEFAULT_RETRIES = 3
     DEFAULT_CONNECTION_ERRORS = {
-      EOFError          => "The remote server dropped the connection",
-      Errno::ECONNRESET => "The remote server reset the connection",
-      Timeout::Error    => "The connection to the remote server timed out",
-      Errno::ETIMEDOUT  => "The connection to the remote server timed out"
+      EOFError               => "The remote server dropped the connection",
+      Errno::ECONNRESET      => "The remote server reset the connection",
+      Timeout::Error         => "The connection to the remote server timed out",
+      Errno::ETIMEDOUT       => "The connection to the remote server timed out",
+      OpenSSL::SSL::SSLError => "The SSL connection to the remote server could not be established"
     }
 
     def self.included(base)


### PR DESCRIPTION
Regard `OpenSSL::SSL::SSLError` as yet another connection error, so it will be wrapped in a `ActiveMerchant::ConnectionError`, and follow our normal path when handling those.

@odorcicd @jduff 
