### PR TITLE
Raise InvalidCurrencyCodeError instead of NoMethodError for nil currencies

### DIFF
--- a/lib/active_utils/common/currency_code.rb
+++ b/lib/active_utils/common/currency_code.rb
@@ -37,7 +37,7 @@ module ActiveMerchant
     }
 
     def self.standardize(code)
-      code = code.upcase
+      code = code.upcase unless code.nil?
 
       return code if is_iso?(code)
       NON_ISO_TO_ISO[code] || raise(InvalidCurrencyCodeError, "#{code} is not an ISO currency, nor can it be converted to one.")

--- a/lib/active_utils/version.rb
+++ b/lib/active_utils/version.rb
@@ -1,3 +1,3 @@
 module ActiveUtils
-  VERSION = "2.1.0"
+  VERSION = "2.1.1"
 end

--- a/test/unit/currency_code_test.rb
+++ b/test/unit/currency_code_test.rb
@@ -28,4 +28,10 @@ class CurrencyCodeTest < Test::Unit::TestCase
       CurrencyCode.standardize('Not Real')
     end
   end
+
+  def test_nil_code_should_raise_InvalidCurrencyCodeError
+    assert_raise InvalidCurrencyCodeError do
+      CurrencyCode.standardize(nil)
+    end
+  end
 end


### PR DESCRIPTION
Trivially small followup to https://github.com/Shopify/active_utils/pull/30. Makes more sense to get an InvalidCurrencyCodeError than a NoMethodError when trying to standardize a nil currency code

@jeromecornet 
@Smcchoi 
