### PR TITLE
Move to Minitest

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,12 +1,8 @@
-#!/usr/bin/env ruby
-$:.unshift(File.dirname(__FILE__) + '/../lib')
-
-require 'rubygems'
-require 'bundler'
-Bundler.setup
-
-require 'test/unit'
 require 'active_utils'
+
+require 'minitest/autorun'
+
 require 'mocha'
+require 'mocha/mini_test'
 
 include ActiveMerchant

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ConnectionTest < Test::Unit::TestCase
+class ConnectionTest < Minitest::Test
 
   def setup
     @ok = stub(:code => 200, :message => 'OK', :body => 'success')
@@ -52,25 +52,25 @@ class ConnectionTest < Test::Unit::TestCase
   end
 
   def test_get_raises_argument_error_if_passed_data
-    assert_raise(ArgumentError) do
+    assert_raises(ArgumentError) do
       @connection.request(:get, 'data', {})
     end
   end
 
   def test_request_raises_when_request_method_not_supported
-    assert_raise(ArgumentError) do
+    assert_raises(ArgumentError) do
       @connection.request(:head, nil, {})
     end
   end
 
   def test_override_max_retries
-    assert_not_equal 1, @connection.max_retries
+    refute_equal 1, @connection.max_retries
     @connection.max_retries = 1
     assert_equal 1, @connection.max_retries
   end
 
   def test_override_ssl_version
-    assert_not_equal :SSLv3, @connection.ssl_version
+    refute_equal :SSLv3, @connection.ssl_version
     @connection.ssl_version = :SSLv3
     assert_equal :SSLv3, @connection.ssl_version
   end
@@ -133,9 +133,7 @@ class ConnectionTest < Test::Unit::TestCase
     @connection.logger.expects(:info).never
     Net::HTTP.any_instance.expects(:post).times(2).raises(Errno::ECONNREFUSED).then.returns(@ok)
 
-    assert_nothing_raised do
-      @connection.request(:post, '')
-    end
+    @connection.request(:post, '')
   end
 
   def test_failure_limit_reached
@@ -152,9 +150,7 @@ class ConnectionTest < Test::Unit::TestCase
 
     @connection.retry_safe = true
 
-    assert_nothing_raised do
-      @connection.request(:post, '')
-    end
+    @connection.request(:post, '')
   end
 
   def test_mixture_of_failures_with_retry_safe_enabled

--- a/test/unit/country_code_test.rb
+++ b/test/unit/country_code_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class CountryCodeTest < Test::Unit::TestCase
+class CountryCodeTest < Minitest::Test
   def test_alpha2_country_code
     code = CountryCode.new('CA')
     assert_equal 'CA', code.value
@@ -26,6 +26,6 @@ class CountryCodeTest < Test::Unit::TestCase
   end
 
   def test_invalid_code_format
-    assert_raise(CountryCodeFormatError){ CountryCode.new('Canada') }
+    assert_raises(CountryCodeFormatError){ CountryCode.new('Canada') }
   end
 end

--- a/test/unit/country_test.rb
+++ b/test/unit/country_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class CountryTest < Test::Unit::TestCase
+class CountryTest < Minitest::Test
   def test_country_from_hash
     country = Country.new(:name => 'Canada', :alpha2 => 'CA', :alpha3 => 'CAN', :numeric => '124')
     assert_equal 'CA', country.code(:alpha2).value
@@ -33,7 +33,7 @@ class CountryTest < Test::Unit::TestCase
   end
 
   def test_find_unknown_country_name
-    assert_raise(InvalidCountryCodeError) do
+    assert_raises(InvalidCountryCodeError) do
       Country.find('Asskickistan')
     end
   end
@@ -55,7 +55,7 @@ class CountryTest < Test::Unit::TestCase
   end
 
   def test_raise_on_nil_name
-    assert_raise(InvalidCountryCodeError) do
+    assert_raises(InvalidCountryCodeError) do
       Country.find(nil)
     end
   end

--- a/test/unit/currency_code_test.rb
+++ b/test/unit/currency_code_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class CurrencyCodeTest < Test::Unit::TestCase
+class CurrencyCodeTest < Minitest::Test
   def test_is_iso_should_return_true_for_iso_currencies
     assert CurrencyCode.is_iso?('CAD')
     assert CurrencyCode.is_iso?('USD')
@@ -24,13 +24,13 @@ class CurrencyCodeTest < Test::Unit::TestCase
   end
 
   def test_standardize_should_raise_for_unknwon_currencies
-    assert_raise InvalidCurrencyCodeError do
+    assert_raises CurrencyCode::InvalidCurrencyCodeError do
       CurrencyCode.standardize('Not Real')
     end
   end
 
   def test_nil_code_should_raise_InvalidCurrencyCodeError
-    assert_raise InvalidCurrencyCodeError do
+    assert_raises CurrencyCode::InvalidCurrencyCodeError do
       CurrencyCode.standardize(nil)
     end
   end

--- a/test/unit/network_connection_retries_test.rb
+++ b/test/unit/network_connection_retries_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'openssl'
 require 'net/http'
 
-class NetworkConnectionRetriesTest < Test::Unit::TestCase
+class NetworkConnectionRetriesTest < Minitest::Test
   class MyNewError < StandardError
   end
 
@@ -42,10 +42,8 @@ class NetworkConnectionRetriesTest < Test::Unit::TestCase
   def test_failure_then_success_with_recoverable_exception
     @requester.expects(:post).times(2).raises(Errno::ECONNREFUSED).then.returns(@ok)
 
-    assert_nothing_raised do
-      retry_exceptions do
-        @requester.post
-      end
+    retry_exceptions do
+      @requester.post
     end
   end
 
@@ -73,10 +71,8 @@ class NetworkConnectionRetriesTest < Test::Unit::TestCase
   def test_failure_then_success_with_retry_safe_enabled
     @requester.expects(:post).times(2).raises(EOFError).then.returns(@ok)
 
-    assert_nothing_raised do
-      retry_exceptions :retry_safe => true do
-        @requester.post
-      end
+    retry_exceptions :retry_safe => true do
+      @requester.post
     end
   end
 
@@ -85,10 +81,8 @@ class NetworkConnectionRetriesTest < Test::Unit::TestCase
     @logger.expects(:info).with(regexp_matches(/success/))
     @requester.expects(:post).times(2).raises(EOFError).then.returns(@ok)
 
-    assert_nothing_raised do
-      retry_exceptions(:logger => @logger, :retry_safe => true) do
-        @requester.post
-      end
+    retry_exceptions(:logger => @logger, :retry_safe => true) do
+      @requester.post
     end
   end
 

--- a/test/unit/post_data_test.rb
+++ b/test/unit/post_data_test.rb
@@ -4,7 +4,7 @@ class MyPost < ActiveMerchant::PostData
   self.required_fields = [ :ccnumber, :ccexp, :firstname, :lastname, :username, :password, :order_id, :key, :time ]
 end
 
-class PostDataTest < Test::Unit::TestCase
+class PostDataTest < Minitest::Test
   def teardown
     ActiveMerchant::PostData.required_fields = []
   end

--- a/test/unit/posts_data_test.rb
+++ b/test/unit/posts_data_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'active_support/core_ext/class'
 
-class PostsDataTest < Test::Unit::TestCase
+class PostsDataTest < Minitest::Test
 
   class SSLPoster
     include PostsData

--- a/test/unit/utils_test.rb
+++ b/test/unit/utils_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class UtilsTest < Test::Unit::TestCase
+class UtilsTest < Minitest::Test
   def test_unique_id_should_be_32_chars_and_alphanumeric
     assert_match /^\w{32}$/, ActiveMerchant::Utils.generate_unique_id
   end

--- a/test/unit/validateable_test.rb
+++ b/test/unit/validateable_test.rb
@@ -13,7 +13,7 @@ class Dood
 
 end
 
-class ValidateableTest < Test::Unit::TestCase
+class ValidateableTest < Minitest::Test
 
   def setup
     @dood = Dood.new


### PR DESCRIPTION
- Update assertions to match those provided by Minitest
- No need for shebang in test_helper
- No need for `Bundler.setup` in test_helper
- `assert_nothing_raised` isn't available any more. Stub it out for the
  time being.

@jamesmacaulay @odorcicd 
