### PR TITLE
Add proxy support for connection

### DIFF
--- a/lib/active_utils/common/connection.rb
+++ b/lib/active_utils/common/connection.rb
@@ -31,6 +31,8 @@ module ActiveMerchant
     attr_accessor :tag
     attr_accessor :ignore_http_status
     attr_accessor :max_retries
+    attr_accessor :proxy_address
+    attr_accessor :proxy_port
 
     def initialize(endpoint)
       @endpoint     = endpoint.is_a?(URI) ? endpoint : URI.parse(endpoint)
@@ -43,6 +45,8 @@ module ActiveMerchant
       @max_retries  = MAX_RETRIES
       @ignore_http_status = false
       @ssl_version = nil
+      @proxy_address = nil
+      @proxy_port = nil
     end
 
     def request(method, body, headers = {})
@@ -88,7 +92,7 @@ module ActiveMerchant
 
     private
     def http
-      http = Net::HTTP.new(endpoint.host, endpoint.port)
+      http = Net::HTTP.new(endpoint.host, endpoint.port, proxy_address, proxy_port)
       configure_debugging(http)
       configure_timeouts(http)
       configure_ssl(http)


### PR DESCRIPTION
Fixes #2 by using the built-in proxy support from `Net::HTTP`

@jamesmacaulay @csaunders 
