### PR TITLE
Generate message for all possible ConnectionError

### DIFF
--- a/lib/active_utils/common/network_connection_retries.rb
+++ b/lib/active_utils/common/network_connection_retries.rb
@@ -28,7 +28,7 @@ module ActiveMerchant
         rescue Zlib::BufError => e
           raise ActiveMerchant::InvalidResponseError, "The remote server replied with an invalid response"
         rescue *connection_errors.keys => e
-          raise ActiveMerchant::ConnectionError, connection_errors[e.class]
+          raise ActiveMerchant::ConnectionError, derived_error_message(connection_errors, e.class)
         end
       end
     end
@@ -68,6 +68,11 @@ module ActiveMerchant
     private
     def log_with_retry_details(logger, attempts, time, message, tag)
       NetworkConnectionRetries.log(logger, :info, "connection_attempt=%d connection_request_time=%.4fs connection_msg=\"%s\"" % [attempts, time, message], tag)
+    end
+
+    def derived_error_message(errors, klass)
+      key = (errors.keys & klass.ancestors).first
+      key ? errors[key] : nil
     end
   end
 end

--- a/test/unit/network_connection_retries_test.rb
+++ b/test/unit/network_connection_retries_test.rb
@@ -14,11 +14,62 @@ class NetworkConnectionRetriesTest < Minitest::Test
     @ok = stub(:code => 200, :message => 'OK', :body => 'success')
   end
 
-  def test_unrecoverable_exception
-    assert_raises(ActiveMerchant::ConnectionError) do
+  def test_eoferror_raises_correctly
+    raised = assert_raises(ActiveMerchant::ConnectionError) do
       retry_exceptions do
         raise EOFError
       end
+    end
+    assert_equal "The remote server dropped the connection", raised.message
+  end
+
+  def test_econnreset_raises_correctly
+    raised = assert_raises(ActiveMerchant::ConnectionError) do
+      retry_exceptions do
+        raise Errno::ECONNRESET
+      end
+    end
+    assert_equal "The remote server reset the connection", raised.message
+  end
+
+  def test_timeout_errors_raise_correctly
+    exceptions = [Timeout::Error, Errno::ETIMEDOUT]
+    if RUBY_VERSION >= '2.0.0'
+      exceptions += [Net::ReadTimeout, Net::OpenTimeout]
+    end
+
+    exceptions.each do |exception|
+      raised = assert_raises(ActiveMerchant::ConnectionError) do
+        retry_exceptions do
+          raise exception
+        end
+      end
+      assert_equal "The connection to the remote server timed out", raised.message
+    end
+  end
+
+  def test_socket_error_raises_correctly
+    raised = assert_raises(ActiveMerchant::ConnectionError) do
+      retry_exceptions do
+        raise SocketError
+      end
+    end
+    assert_equal "The connection to the remote server could not be established", raised.message
+  end
+
+  def test_ssl_errors_raise_correctly
+    exceptions = [OpenSSL::SSL::SSLError]
+    if RUBY_VERSION >= '2.1.0'
+      exceptions += [OpenSSL::SSL::SSLErrorWaitWritable, OpenSSL::SSL::SSLErrorWaitReadable]
+    end
+
+    exceptions.each do |exception|
+      raised = assert_raises(ActiveMerchant::ConnectionError) do
+        retry_exceptions do
+          raise exception
+        end
+      end
+      assert_equal "The SSL connection to the remote server could not be established", raised.message
     end
   end
 


### PR DESCRIPTION
Unrecoverable exceptions generate an `ActiveMerchant::ConnectionError` along with a helpful error message, as defined by the `DEFAULT_CONNECTION_ERRORS` constant.

However, there are a few exceptions that would be rescued by the code but would not generate an exception message, because these exceptions are _subclasses_ of those defined in the constant:

``` rb
require 'active_utils'
require 'net/http'
require 'net/https'

class Class
  def descendants
    ObjectSpace.each_object(::Class).select {|klass| klass < self }
  end
end

Timeout::Error.descendants
# => [Net::ReadTimeout, Net::OpenTimeout]

OpenSSL::SSL::SSLError.descendants
# => [OpenSSL::SSL::SSLErrorWaitWritable, OpenSSL::SSL::SSLErrorWaitReadable]
```

This adds the ability to look for the appropriate error message in the `DEFAULT_CONNECTION_ERRORS` constant via the exception that occurred _or_ its ancestors.  This way, a message should always be returned, and we will be able to disambiguate a `Net::ReadTimeout` from a `OpenSSL::SSL::SSLErrorWaitReadable` from outside ActiveMerchant by observing the ConnectionError message.
