### PR TITLE
Remove unused and duplicate method

### DIFF
--- a/lib/active_utils/connection.rb
+++ b/lib/active_utils/connection.rb
@@ -137,19 +137,6 @@ module ActiveUtils
       end
     end
 
-    def handle_response(response)
-      if @ignore_http_status then
-        return response.body
-      else
-        case response.code.to_i
-        when 200...300
-          response.body
-        else
-          raise ResponseError.new(response)
-        end
-      end
-    end
-
     def debug(message, tag = nil)
       log(:debug, message, tag)
     end


### PR DESCRIPTION
`Connection#handle_response` is unused.

I think that we should use `PostsData#handle_response`.
