### PR TITLE
Log a warning if posting to a plaintext endpoint

### DIFF
--- a/lib/active_utils/common/posts_data.rb
+++ b/lib/active_utils/common/posts_data.rb
@@ -38,6 +38,7 @@ module ActiveMerchant #:nodoc:
 
     def raw_ssl_request(method, endpoint, data, headers = {})
       logger.warn "#{self.class} using ssl_strict=false, which is insecure" if logger unless ssl_strict
+      logger.warn "#{self.class} posting to plaintext endpoint, which is insecure" if logger unless endpoint =~ /^https:/
 
       connection = new_connection(endpoint)
       connection.open_timeout = open_timeout


### PR DESCRIPTION
This is mostly precautionary, as all valid endpoints should be providing service over SSL.

@ntalbott @Shopify/payments 
