### PR TITLE
Use ActiveUtils::HTTPRequestError as base exception class

### DIFF
--- a/lib/active_utils.rb
+++ b/lib/active_utils.rb
@@ -3,6 +3,9 @@ require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/core_ext/hash/conversions'
 require 'active_support/core_ext/class/attribute'
 
+require 'active_utils/error'
+require 'active_utils/version'
+
 module ActiveUtils
   autoload :NetworkConnectionRetries,  'active_utils/network_connection_retries'
   autoload :Connection,                'active_utils/connection'
@@ -10,12 +13,6 @@ module ActiveUtils
   autoload :CountryCode,               'active_utils/country'
   autoload :InvalidCountryCodeError,   'active_utils/country'
   autoload :CountryCodeFormatError,    'active_utils/country'
-  autoload :ActiveUtilsError,          'active_utils/error'
-  autoload :ConnectionError,           'active_utils/error'
-  autoload :RetriableConnectionError,  'active_utils/error'
-  autoload :ResponseError,             'active_utils/error'
-  autoload :ClientCertificateError,    'active_utils/error'
-  autoload :InvalidResponseError,      'active_utils/error'
   autoload :PostData,                  'active_utils/post_data'
   autoload :PostsData,                 'active_utils/posts_data'
   autoload :RequiresParameters,        'active_utils/requires_parameters'

--- a/lib/active_utils/error.rb
+++ b/lib/active_utils/error.rb
@@ -1,14 +1,16 @@
 module ActiveUtils #:nodoc:
-  class ActiveUtilsError < StandardError #:nodoc:
+  class HTTPRequestError < StandardError #:nodoc:
   end
 
-  class ConnectionError < ActiveUtilsError # :nodoc:
+  ActiveUtilsError = HTTPRequestError #:nodoc:
+
+  class ConnectionError < HTTPRequestError # :nodoc:
   end
 
   class RetriableConnectionError < ConnectionError # :nodoc:
   end
 
-  class ResponseError < ActiveUtilsError # :nodoc:
+  class ResponseError < HTTPRequestError # :nodoc:
     attr_reader :response
 
     def initialize(response, message = nil)
@@ -21,9 +23,9 @@ module ActiveUtils #:nodoc:
     end
   end
 
-  class ClientCertificateError < ActiveUtilsError # :nodoc
+  class ClientCertificateError < HTTPRequestError # :nodoc
   end
 
-  class InvalidResponseError < ActiveUtilsError # :nodoc
+  class InvalidResponseError < HTTPRequestError # :nodoc
   end
 end


### PR DESCRIPTION
This is a start to clean up the exception mess.

Turns out we already have a common ancestor to all the HTTP-related exceptions, but it is awkwardly named `ActiveUtils::ActiveUtilsException`. This renames this exception class to `ActiveUtils::HTTPRequestError`, but keeps the old name available as an alias for backwards compatibility

@kmcphillips @robfoster @garethson 