### PR TITLE
Allow proxy address and port configuration

### DIFF
--- a/lib/active_utils/posts_data.rb
+++ b/lib/active_utils/posts_data.rb
@@ -22,6 +22,9 @@ module ActiveUtils #:nodoc:
 
       base.class_attribute :logger
       base.class_attribute :wiredump_device
+
+      base.class_attribute :proxy_address
+      base.class_attribute :proxy_port
     end
 
     def ssl_get(endpoint, headers={})
@@ -55,6 +58,9 @@ module ActiveUtils #:nodoc:
       connection.pem_password = @options[:pem_password] if @options
 
       connection.ignore_http_status = @options[:ignore_http_status] if @options
+
+      connection.proxy_address = proxy_address
+      connection.proxy_port = proxy_port
 
       connection.request(method, data, headers)
     end

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -124,6 +124,24 @@ class ConnectionTest < Minitest::Test
     assert_equal "/bogus", @connection.send(:http).ca_path
   end
 
+  def test_default_proxy_address_is_nil
+    assert_equal nil, @connection.proxy_address
+  end
+
+  def test_default_proxy_port_is_nil
+    assert_equal nil, @connection.proxy_port
+  end
+
+  def test_override_proxy_address
+    @connection.proxy_address = "http://proxy.example.com"
+    assert_equal "http://proxy.example.com", @connection.proxy_address
+  end
+
+  def test_override_proxy_port
+    @connection.proxy_port = "8888"
+    assert_equal "8888", @connection.proxy_port
+  end
+
   def test_unrecoverable_exception
     @connection.logger.expects(:info).once
     Net::HTTP.any_instance.expects(:post).raises(EOFError)

--- a/test/unit/posts_data_test.rb
+++ b/test/unit/posts_data_test.rb
@@ -55,4 +55,10 @@ class PostsDataTest < Minitest::Test
     @poster.raw_ssl_request(:post, "https://shopify.com", "", {})
   end
 
+  def test_set_proxy_address_and_port
+    SSLPoster.proxy_address = 'http://proxy.example.com'
+    SSLPoster.proxy_port = '8888'
+    assert_equal @poster.proxy_address, 'http://proxy.example.com'
+    assert_equal @poster.proxy_port, '8888'
+  end
 end


### PR DESCRIPTION
Allow access to proxy address and port for post_data.
Fixes: https://github.com/Shopify/active_utils/pull/44