### PR TITLE
Define array once

### DIFF
--- a/lib/active_utils/country.rb
+++ b/lib/active_utils/country.rb
@@ -310,7 +310,7 @@ module ActiveUtils #:nodoc:
       { :alpha2 => 'ZM', :name => 'Zambia', :alpha3 => 'ZMB', :numeric => '894' },
       { :alpha2 => 'ZW', :name => 'Zimbabwe', :alpha3 => 'ZWE', :numeric => '716' },
       { :alpha2 => 'AX', :name => 'Åland Islands', :alpha3 => 'ALA', :numeric => '248' }
-    ]
+    ] unless defined?(COUNTRIES)
 
     def self.find(name)
       raise InvalidCountryCodeError, "Cannot lookup country for an empty name" if name.blank?


### PR DESCRIPTION
Saves me from having to read about redefining array. Think it has to do with eager load which we are using for some reason in our tests.

> ruby-2.2.2/gems/active_utils-2.2.3/lib/active_utils/common/country.rb:65: warning: already initialized constant ActiveMerchant::Country::COUNTRIES