### PR TITLE
add Sint Maarten (Netherlands Part) to the list of countries

### DIFF
--- a/lib/active_utils/country.rb
+++ b/lib/active_utils/country.rb
@@ -262,6 +262,7 @@ module ActiveUtils #:nodoc:
       { :alpha2 => 'SC', :name => 'Seychelles', :alpha3 => 'SYC', :numeric => '690' },
       { :alpha2 => 'SL', :name => 'Sierra Leone', :alpha3 => 'SLE', :numeric => '694' },
       { :alpha2 => 'SG', :name => 'Singapore', :alpha3 => 'SGP', :numeric => '702' },
+      { :alpha2 => 'SX', :name => 'Sint Maarten (Netherlands Part)', :alpha3 => 'SXM', :numberic => '534' },
       { :alpha2 => 'SK', :name => 'Slovakia', :alpha3 => 'SVK', :numeric => '703' },
       { :alpha2 => 'SI', :name => 'Slovenia', :alpha3 => 'SVN', :numeric => '705' },
       { :alpha2 => 'SB', :name => 'Solomon Islands', :alpha3 => 'SLB', :numeric => '090' },


### PR DESCRIPTION
Sint Maarten (SX) was not in the list of countries but was added to the ISO list. (ISO 3166-2 http://www.iso.org/iso/home/standards/country_codes/updates_on_iso_3166.htm?show=tab3) 

This adds that country code to the list of countries.

@wvanbergen @disaacs 