### PR TITLE
Add method to check if a country uses postal codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ActiveUtils changelog
 
+### Version 3.2.0 (Oct. 13, 2015)
+- Add #uses_postal_codes? to `ActiveUtils::Country`
+
 ### Version 3.1.0 (Sept. 30, 2015)
 - Use ActiveUtils::HTTPRequestError as base exception class
 - Add proxy address and port configuration

--- a/lib/active_utils/country.rb
+++ b/lib/active_utils/country.rb
@@ -313,6 +313,16 @@ module ActiveUtils #:nodoc:
       { :alpha2 => 'AX', :name => 'Åland Islands', :alpha3 => 'ALA', :numeric => '248' }
     ]
 
+    COUNTRIES_THAT_DO_NOT_USE_POSTALCODES = %w(
+      QA BZ BS BF BJ AG AE AI AO AW HK
+      FJ ML JM ZW YE UG TV TT TG TD PA
+      CW
+    )
+
+    def uses_postal_codes?
+      !COUNTRIES_THAT_DO_NOT_USE_POSTALCODES.include?(code(:alpha2).value)
+    end
+
     def self.find(name)
       raise InvalidCountryCodeError, "Cannot lookup country for an empty name" if name.blank?
 

--- a/lib/active_utils/version.rb
+++ b/lib/active_utils/version.rb
@@ -1,3 +1,3 @@
 module ActiveUtils
-  VERSION = "3.1.0"
+  VERSION = "3.2.0"
 end

--- a/test/unit/country_test.rb
+++ b/test/unit/country_test.rb
@@ -65,4 +65,13 @@ class CountryTest < Minitest::Test
     assert_equal(country_names.sort, country_names)
   end
 
+  def test_canada_uses_postal_codes
+    canada = Country.find('Canada')
+    assert canada.uses_postal_codes?
+  end
+
+  def test_qatar_does_not_use_postal_codes
+    qatar = Country.find('Qatar')
+    refute qatar.uses_postal_codes?
+  end
 end


### PR DESCRIPTION
This logic already lives internally in Shopify. Moving it here so it can be reused.

Review @wvanbergen @disaacs
cc @Shopify/shipping 