### PR TITLE
add malaysian non iso currency RM => MYR

### DIFF
--- a/lib/active_utils/currency_code.rb
+++ b/lib/active_utils/currency_code.rb
@@ -29,6 +29,7 @@ module ActiveUtils
       "NMP" => "MXN", # Mexican Pesos
       "NTD" => "TWD", # New Taiwan Dollars / Taiwan New Dollars
       "RDD" => "DOP", # Dominican Pesos
+      "RM" => "MYR",  # Malaysia Ringgit
       "RMB" => "CNY", # Chinese Renminbi
       "SFR" => "CHF", # Swiss Francs
       "SID" => "SGD", # Singapore Dollars


### PR DESCRIPTION
## Problem
RM isn't recognized as a currency code.

## Solution
Add a mapping to the MYR ISO code.

@Smcchoi  @KnVerey 

@girasquid 