### PR TITLE
Test for Rails 5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,20 @@ rvm:
 - "1.9"
 - "2.0"
 - "2.1"
-- "2.2"
+- "2.2.2"
 
 gemfile:
 - Gemfile.activesupport32
 - Gemfile.activesupport40
 - Gemfile.activesupport41
 - Gemfile.activesupport42
+- Gemfile.activesupport50
+
+matrix:
+  exclude:
+    - rvm: "1.9"
+      gemfile: Gemfile.activesupport50
+    - rvm: "2.0"
+      gemfile: Gemfile.activesupport50
+    - rvm: "2.1"
+      gemfile: Gemfile.activesupport50

--- a/Gemfile.activesupport50
+++ b/Gemfile.activesupport50
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+gemspec
+
+gem 'activesupport', '~> 5.0.0'

--- a/active_utils.gemspec
+++ b/active_utils.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "active_utils"
 
-  s.add_dependency('activesupport', '>= 3.2')
+  s.add_dependency('activesupport', '>= 3.2', '< 5.1.0')
   s.add_dependency('i18n')
 
   s.add_development_dependency('rake')


### PR DESCRIPTION
There shouldn't be any Rails 5 compatibility issues, but this PR adds some tests to be certain. It also adds an upper version restriction on the ActiveSupport dependency so that we'll have to explicitly support it when the version goes up.

@kmcphillips @wvanbergen 