### PR TITLE
Add a delay option for connection retries

### DIFF
--- a/lib/active_utils/network_connection_retries.rb
+++ b/lib/active_utils/network_connection_retries.rb
@@ -49,12 +49,18 @@ module ActiveUtils
         retries -= 1
 
         log_with_retry_details(options[:logger], initial_retries-retries, Time.now.to_f - request_start, e.message, options[:tag])
-        retry unless retries.zero?
+        unless retries.zero?
+          Kernel.sleep(options[:delay]) if options[:delay]
+          retry
+        end
         raise ActiveUtils::ConnectionError, e.message
       rescue ActiveUtils::ConnectionError, ActiveUtils::InvalidResponseError => e
         retries -= 1
         log_with_retry_details(options[:logger], initial_retries-retries, Time.now.to_f - request_start, e.message, options[:tag])
-        retry if (options[:retry_safe] || retry_safe) && !retries.zero?
+        if (options[:retry_safe] || retry_safe) && !retries.zero?
+          Kernel.sleep(options[:delay]) if options[:delay]
+          retry
+        end
         raise
       end
     end

--- a/test/unit/network_connection_retries_test.rb
+++ b/test/unit/network_connection_retries_test.rb
@@ -149,6 +149,24 @@ class NetworkConnectionRetriesTest < Minitest::Test
     end
   end
 
+  def test_delay_between_retries
+    @requester.expects(:post).times(2).raises(EOFError).then.returns(@ok)
+    Kernel.expects(sleep: 0.5)
+
+    retry_exceptions retry_safe: true, delay: 0.5 do
+      @requester.post
+    end
+  end
+
+  def test_no_delay_without_specified_option
+    @requester.expects(:post).times(2).raises(EOFError).then.returns(@ok)
+    Kernel.expects(sleep: 0.5).never
+
+    retry_exceptions retry_safe: true do
+      @requester.post
+    end
+  end
+
   def test_failure_with_ssl_certificate
     @requester.expects(:post).raises(OpenSSL::X509::CertificateError)
 


### PR DESCRIPTION
In our codebase, we saw occurences where the connection fails very fast:
~ 0.04 second and retried 3 time in under 0.2 second.

Retrying this quickly doesn't leave alot of time for the network / services to recover. Adding a delay between those connection retries as an option could be beneficial to let the network recover

From our logs:
`[Module] connection_attempt=1 connection_request_time=0.0445s`
`[Module] connection_attempt=2 connection_request_time=0.0451s`
`[Module] connection_attempt=3 connection_request_time=0.0439s`