### PR TITLE
Adding timestamp to network connection retries

### DIFF
--- a/lib/active_utils/network_connection_retries.rb
+++ b/lib/active_utils/network_connection_retries.rb
@@ -67,7 +67,7 @@ module ActiveUtils
 
     def self.log(logger, level, message, tag=nil)
       tag ||= self.class.to_s
-      message = "[#{tag}] #{message}"
+      message = "[#{Time.now}] [#{tag}] #{message}"
       logger.send(level, message) if logger
     end
 


### PR DESCRIPTION
Follow up of: https://github.com/Shopify/active_utils/pull/70

When multiple connection retries occur in succession, a timestamp of when they occurred would be helpful to debug the issue. This commit adds a timestamp to the logs