### PR TITLE
Reduce default gateway timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ActiveUtils changelog
 
+### Unrelease
+- Reduced default PostsData open_timeout from 60 seconds to 2, and read_timeout from 60 seconds to 10. Subclasses can and should override those values.
+
 ### Version 3.2.5 (Feb. 2, 2017)
 - Add the `TMT` currency in the supported currency codes
 

--- a/lib/active_utils/posts_data.rb
+++ b/lib/active_utils/posts_data.rb
@@ -12,10 +12,10 @@ module ActiveUtils #:nodoc:
       base.retry_safe = false
 
       base.class_attribute :open_timeout
-      base.open_timeout = 60
+      base.open_timeout = 2
 
       base.class_attribute :read_timeout
-      base.read_timeout = 60
+      base.read_timeout = 10
 
       base.class_attribute :max_retries
       base.max_retries = Connection::MAX_RETRIES


### PR DESCRIPTION
60 seconds for both `open` and `read` timeout is quite insane if you ask me.

Also note that `read_timeout` only raise if not a single byte can be read for that amount of time, if the gateway send 1 byte every seconds, there's basically no timeout.

@PhilibertDugas @wvanbergen @lucasuyezu @jonathankwok (pinging the last 4 contributors).

cc @Shopify/webscale 