### PR TITLE
Replace Kosovo's code from KV to XK

### DIFF
--- a/lib/active_utils/country.rb
+++ b/lib/active_utils/country.rb
@@ -180,7 +180,7 @@ module ActiveUtils #:nodoc:
       { :alpha2 => 'KI', :name => 'Kiribati', :alpha3 => 'KIR', :numeric => '296' },
       { :alpha2 => 'KP', :name => 'Korea, Democratic People\'s Republic of', :alpha3 => 'PRK', :numeric => '408' },
       { :alpha2 => 'KR', :name => 'Korea, Republic of', :alpha3 => 'KOR', :numeric => '410' },
-      { :alpha2 => 'KV', :name => 'Kosovo', :alpha3 => 'KSV', :numeric => '377' },
+      { :alpha2 => 'XK', :name => 'Kosovo', :alpha3 => 'XKX', :numeric => '377' },
       { :alpha2 => 'KW', :name => 'Kuwait', :alpha3 => 'KWT', :numeric => '414' },
       { :alpha2 => 'KG', :name => 'Kyrgyzstan', :alpha3 => 'KGZ', :numeric => '417' },
       { :alpha2 => 'LA', :name => 'Lao People\'s Democratic Republic', :alpha3 => 'LAO', :numeric => '418' },


### PR DESCRIPTION
### Problem
According to https://countrycode.org/kosovo and https://en.wikipedia.org/wiki/Kosovo, Kosovo's 2 digit ISO code is `XK`.

### Solution
Replace `KV` with `XK`.