### PR TITLE
Version bump 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # ActiveUtils changelog
 
-### Unrelease
+### Version 3.3.0 (Mar. 10, 2017)
 - Reduced default PostsData open_timeout from 60 seconds to 2, and read_timeout from 60 seconds to 10. Subclasses can and should override those values.
+- Replace Kosovo's alpha 2 and alpha 3 ISO codes from `KV` to `XK` and from `KSV` to `XKX`.
 
 ### Version 3.2.5 (Feb. 2, 2017)
 - Add the `TMT` currency in the supported currency codes

--- a/lib/active_utils/version.rb
+++ b/lib/active_utils/version.rb
@@ -1,3 +1,3 @@
 module ActiveUtils
-  VERSION = "3.2.5"
+  VERSION = "3.3.0"
 end


### PR DESCRIPTION
Bumping to 3.3.0 to release changes implemented in #78 and #79.
