### PR TITLE
Change active_support dependancy to < 5.2.0

### DIFF
--- a/active_utils.gemspec
+++ b/active_utils.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "active_utils"
 
-  s.add_dependency('activesupport', '>= 3.2', '< 5.1.0')
+  s.add_dependency('activesupport', '>= 3.2', '< 5.2.0')
   s.add_dependency('i18n')
 
   s.add_development_dependency('rake')


### PR DESCRIPTION
Lets make this work for Rails 5.1.x.

Change the dependancy to allow `active_support` < 5.2.0