### PR TITLE
Updated Libyan Arab Jamahirya to Libya in active_utils

### DIFF
--- a/lib/active_utils/country.rb
+++ b/lib/active_utils/country.rb
@@ -188,7 +188,7 @@ module ActiveUtils #:nodoc:
       { :alpha2 => 'LB', :name => 'Lebanon', :alpha3 => 'LBN', :numeric => '422' },
       { :alpha2 => 'LS', :name => 'Lesotho', :alpha3 => 'LSO', :numeric => '426' },
       { :alpha2 => 'LR', :name => 'Liberia', :alpha3 => 'LBR', :numeric => '430' },
-      { :alpha2 => 'LY', :name => 'Libyan Arab Jamahiriya', :alpha3 => 'LBY', :numeric => '434' },
+      { :alpha2 => 'LY', :name => 'Libya', :alpha3 => 'LBY', :numeric => '434' },
       { :alpha2 => 'LI', :name => 'Liechtenstein', :alpha3 => 'LIE', :numeric => '438' },
       { :alpha2 => 'LT', :name => 'Lithuania', :alpha3 => 'LTU', :numeric => '440' },
       { :alpha2 => 'LU', :name => 'Luxembourg', :alpha3 => 'LUX', :numeric => '442' },


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
This PR is to update the country name for Libya (from Libyan Arab Jamahiriya) as it was changed in 2011. This change is to update the display name from "Libyan Arab Jamahiriya" to "Libya".

**How is this accomplished?**
I changed the country name from "Libyan Arab Jamahiriya" to Libya.

**What could go wrong? (if anything)**
As Libya is a subset of the former name, and in fact the former-former name that most people knew the country by beforehand, it would be fairly self-explanatory. The UI component update will change the presentation of the name in the enumerated list and although it will no longer match the full name input but will match the current country name, the name by which it is commonly known. 

**Rollback steps**

It is safe to simply rollback this change.