### PR TITLE
Ghana does not use postal codes

### DIFF
--- a/lib/active_utils/country.rb
+++ b/lib/active_utils/country.rb
@@ -318,7 +318,7 @@ module ActiveUtils #:nodoc:
     COUNTRIES_THAT_DO_NOT_USE_POSTALCODES = %w(
       QA BZ BS BF BJ AG AE AI AO AW HK
       FJ ML JM ZW YE UG TV TT TG TD PA
-      CW
+      CW GH
     )
 
     def uses_postal_codes?


### PR DESCRIPTION
Ghana does not use postal codes, so we should add it to `COUNTRIES_THAT_DO_NOT_USE_POSTALCODES`