### PR TITLE
Add South Sudan to Countries that do not use postal codes

### DIFF
--- a/lib/active_utils/country.rb
+++ b/lib/active_utils/country.rb
@@ -318,7 +318,7 @@ module ActiveUtils #:nodoc:
     COUNTRIES_THAT_DO_NOT_USE_POSTALCODES = %w(
       QA BZ BS BF BJ AG AE AI AO AW HK
       FJ ML JM ZW YE UG TV TT TG TD PA
-      CW GH
+      CW GH SS
     )
 
     def uses_postal_codes?


### PR DESCRIPTION
### What are you trying to accomplish with this PR?
Add South Sudan to countries not requiring postal codes



### How is this accomplished?
By adding South Sudan to the list of such countries in country.rb



### Further Steps
bump new version

CC @georgetzavelas 