### PR TITLE
Add support for Cape Verde (CVE) currency code

### DIFF
--- a/lib/active_utils/currency_code.rb
+++ b/lib/active_utils/currency_code.rb
@@ -6,13 +6,13 @@ module ActiveUtils
     ISO_CURRENCIES = [
       "AED", "ALL", "AMD", "ANG", "AOA", "ARS", "AUD", "AWG", "AZN", "BAM", "BBD", "BDT", "BGN", "BHD",
       "BND", "BOB", "BRL", "BSD", "BTN", "BWP", "BYR", "BZD", "CAD", "CDF", "CHF", "CLP", "CNY", "COP",
-      "CRC", "CZK", "DKK", "DOP", "DZD", "EGP", "ETB", "EUR", "FJD", "GBP", "GEL", "GHS", "GMD", "GTQ",
-      "GYD", "HKD", "HNL", "HRK", "HUF", "IDR", "ILS", "INR", "ISK", "JEP", "JMD", "JOD", "JPY", "KES",
-      "KGS", "KHR", "KRW", "KWD", "KYD", "KZT", "LBP", "LKR", "LTL", "LVL", "MAD", "MDL", "MGA", "MKD",
-      "MMK", "MNT", "MOP", "MUR", "MVR", "MXN", "MYR", "MZN", "NAD", "NGN", "NIO", "NOK", "NPR", "NZD",
-      "OMR", "PEN", "PGK", "PHP", "PKR", "PLN", "PYG", "QAR", "RON", "RSD", "RUB", "RWF", "SAR", "SCR",
-      "SEK", "SGD", "STD", "SYP", "THB", "TMT", "TND", "TRY", "TTD", "TWD", "TZS", "UAH", "UGX", "USD",
-      "UYU", "VEF", "VND", "VUV", "WST", "XAF", "XCD", "XOF", "XPF", "ZAR", "ZMW", 
+      "CRC", "CVE", "CZK", "DKK", "DOP", "DZD", "EGP", "ETB", "EUR", "FJD", "GBP", "GEL", "GHS", "GMD",
+      "GTQ", "GYD", "HKD", "HNL", "HRK", "HUF", "IDR", "ILS", "INR", "ISK", "JEP", "JMD", "JOD", "JPY",
+      "KES", "KGS", "KHR", "KRW", "KWD", "KYD", "KZT", "LBP", "LKR", "LTL", "LVL", "MAD", "MDL", "MGA",
+      "MKD", "MMK", "MNT", "MOP", "MUR", "MVR", "MXN", "MYR", "MZN", "NAD", "NGN", "NIO", "NOK", "NPR",
+      "NZD", "OMR", "PEN", "PGK", "PHP", "PKR", "PLN", "PYG", "QAR", "RON", "RSD", "RUB", "RWF", "SAR",
+      "SCR", "SEK", "SGD", "STD", "SYP", "THB", "TMT", "TND", "TRY", "TTD", "TWD", "TZS", "UAH", "UGX",
+      "USD", "UYU", "VEF", "VND", "VUV", "WST", "XAF", "XCD", "XOF", "XPF", "ZAR", "ZMW", 
     ]
 
     NON_ISO_TO_ISO = {


### PR DESCRIPTION
### What are you trying to accomplish with this PR

Adding Cape Verde (CVE) currency code to currency_code.rb this is required for https://github.com/Shopify/shopify/pull/116995

### Why are you choosing this approach?

ISO code is required for https://github.com/Shopify/shopify/pull/116995

### How is this accomplished?

Adding CVE to ISO_CURRENCIES

### Anything that could go wrong?

Formatting errors, incorrect ISO codes used.

### Checklist

- [x] It is safe to simply rollback this change until https://github.com/Shopify/shopify/pull/116995 is merged.  Afterwards checkout with CVE currency will fail.
- [x] I have followed the relevant [copy and style guidelines](http://styleguide.myshopify.com/).
- [x] I have :tophat:'d these changes ([details](https://vault.shopify.com/developers/Tophatting)).

### Steps to  :tophat:

* Using local active_utils gem of this branch & https://github.com/Shopify/shopify/pull/116995 & https://github.com/Shopify/country_db/pull/46 
* ran rake command to update ISO_CURRENCIES `rake dev:currency:update`
* loaded dev shop locally, set store currency to CVE
* Completed checkout.

### Further Steps

Will need to bump active_utils to new version