### PR TITLE
Add Bolivia (BO) to countries without postal codes

### DIFF
--- a/lib/active_utils/country.rb
+++ b/lib/active_utils/country.rb
@@ -320,7 +320,7 @@ module ActiveUtils #:nodoc:
     COUNTRIES_THAT_DO_NOT_USE_POSTALCODES = %w(
       QA BZ BS BF BJ AG AE AI AO AW HK
       FJ ML JM ZW YE UG TV TT TG TD PA
-      CW GH SS
+      CW GH SS BO
     )
 
     def uses_postal_codes?


### PR DESCRIPTION
According to the list of country codes, Bolivia doesn't require a zip code. I'm simply adding the code to that list.

ref: https://en.wikipedia.org/wiki/List_of_postal_codes

@Shopify/checkout 