### PR TITLE
Use monotonic clock to measure elapsed time

### DIFF
--- a/lib/active_utils/connection.rb
+++ b/lib/active_utils/connection.rb
@@ -50,7 +50,7 @@ module ActiveUtils
     end
 
     def request(method, body, headers = {})
-      request_start = Time.now.to_f
+      request_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
       retry_exceptions(:max_retries => max_retries, :logger => logger, :tag => tag) do
         begin
@@ -87,7 +87,7 @@ module ActiveUtils
       end
 
     ensure
-      info "connection_request_total_time=%.4fs" % [Time.now.to_f - request_start], tag
+      info "connection_request_total_time=%.4fs" % [Process.clock_gettime(Process::CLOCK_MONOTONIC) - request_start], tag
     end
 
     private


### PR DESCRIPTION
The monotonic clock can only move forward and is not subject to changes of the system clock, e.g. corrections due to NTP or VM adjustments.

Same as https://github.com/activemerchant/active_merchant/pull/2566