### PR TITLE
Add Malawi to the COUNTRIES_THAT_DO_NOT_USE_POSTALCODES

### DIFF
--- a/lib/active_utils/country.rb
+++ b/lib/active_utils/country.rb
@@ -319,7 +319,7 @@ module ActiveUtils #:nodoc:
 
     COUNTRIES_THAT_DO_NOT_USE_POSTALCODES = %w(
       QA BZ BS BF BJ AG AE AI AO AW HK
-      FJ ML JM ZW YE UG TV TT TG TD PA
+      FJ ML MW JM ZW YE UG TV TT TG TD PA
       CW GH SS BO
     )
 

--- a/test/unit/country_test.rb
+++ b/test/unit/country_test.rb
@@ -65,6 +65,16 @@ class CountryTest < Minitest::Test
     assert_equal(country_names.sort, country_names)
   end
 
+  def test_countries_that_do_not_use_postalcodes_are_unique
+    country_codes = Country::COUNTRIES_THAT_DO_NOT_USE_POSTALCODES
+    assert_equal(country_codes.uniq.length, country_codes.length)
+  end
+
+  def test_change_to_countries_that_do_not_use_postalcodes_is_intentional
+    country_codes = Country::COUNTRIES_THAT_DO_NOT_USE_POSTALCODES
+    assert_equal(country_codes.length, 27)
+  end
+
   def test_canada_uses_postal_codes
     canada = Country.find('Canada')
     assert canada.uses_postal_codes?


### PR DESCRIPTION
Malawi doesn't require a zip code.

Resources validating: 
- [List of country codes on Wikipedia](https://en.wikipedia.org/wiki/List_of_postal_codes)
- [Global Sourcebook for International Data Management](https://www.grcdi.nl/gsb/malawi.html#HD47786BC96E2D2B155B775A25B9EA1E4EE522815032A2AA2AMalawiA20A2DA5BA5BPostalA20codesA5DA5DA2AA2A00100400D01001301601F02702A02D030) 

Fix https://github.com/Shopify/shopify/issues/177667