### PR TITLE
Add option to allow custom retriable errors in NetworkConnectionRetries

### DIFF
--- a/test/unit/network_connection_retries_test.rb
+++ b/test/unit/network_connection_retries_test.rb
@@ -207,4 +207,12 @@ class NetworkConnectionRetriesTest < Minitest::Test
       end
     end
   end
+
+  def test_retries_with_custom_error_specified
+    @requester.expects(:post).times(2).raises(Errno::ETIMEDOUT).then.returns(@ok)
+
+    retry_exceptions retriable_exceptions: { Errno::ETIMEDOUT => "The connection to the remote server timed out"} do
+      @requester.post
+    end
+  end
 end


### PR DESCRIPTION
Whilst using `retry_exceptions`, I wanted to enable retry on open timeout, but not all timeouts, `safe_retry` is too encompassing and retries on all timeouts.

In order to accomplish this, I felt that the safest way is to allow retrying on specific exceptions, using the same syntax as `connection_exceptions`, but with `retriable_exceptions` as an option


I'm struggling to think of a better name for the parameter since 
```
retry_exceptions retriable_exceptions: { Net::OpenTimeout => "The connection to the remote server timed out"} 
```

reads weirdly