### PR TITLE
Release 3.3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ActiveUtils changelog
 
+### Version 3.3.13 (November 26, 2018)
+- Add support for custom retriable exceptions in `NetworkConnectionRetries#retry_exceptions`
+
 ### Version 3.3.12 (July 11, 2018)
 - Update CA bundle
 

--- a/lib/active_utils/version.rb
+++ b/lib/active_utils/version.rb
@@ -1,3 +1,3 @@
 module ActiveUtils
-  VERSION = "3.3.12"
+  VERSION = "3.3.13"
 end


### PR DESCRIPTION
I tried to follow the releasing instructions in `CONTRIBUTING.md`, but `tag_release` doesn't exist and `release` throws errors.

So I assume I just need to release through shipit

```
rake aborted!
Ignoring byebug-10.0.2 because its extensions are not built. Try: gem pristine byebug --version 10.0.2
ERROR:  Loading command: build (NameError)
	uninitialized constant OpenSSL::SSL::TLS1_VERSION
ERROR:  While executing gem ... (NoMethodError)
    undefined method `invoke_with_build_args' for nil:NilClass
/usr/local/lib/ruby/gems/2.5.0/gems/rake-12.3.1/exe/rake:27:in `<top (required)>'
/usr/local/bin/bundle:30:in `block in <main>'
/usr/local/bin/bundle:22:in `<main>'
Tasks: TOP => release => build
```