### PR TITLE
 Remove the upperbound constraint on ActiveSupport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ sudo: false
 rvm:
 - "2.0"
 - "2.1"
-- "2.2.2"
+- "2.2"
+- "2.3"
+- "2.4"
+- "2.5"
 
 before_install:
 - gem update bundler
@@ -14,6 +17,7 @@ gemfile:
 - gemfiles/Gemfile.activesupport42
 - gemfiles/Gemfile.activesupport50
 - gemfiles/Gemfile.activesupport52
+- gemfiles/Gemfile.activesupport-master
 
 matrix:
   exclude:
@@ -21,7 +25,15 @@ matrix:
       gemfile: gemfiles/Gemfile.activesupport50
     - rvm: "2.0"
       gemfile: gemfiles/Gemfile.activesupport52
+    - rvm: "2.0"
+      gemfile: gemfiles/Gemfile.activesupport-master
     - rvm: "2.1"
       gemfile: gemfiles/Gemfile.activesupport50
     - rvm: "2.1"
       gemfile: gemfiles/Gemfile.activesupport52
+    - rvm: "2.1"
+      gemfile: gemfiles/Gemfile.activesupport-master
+    - rvm: "2.2"
+      gemfile: gemfiles/Gemfile.activesupport-master
+    - rvm: "2.3"
+      gemfile: gemfiles/Gemfile.activesupport-master

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ script: bundle exec rake test
 sudo: false
 
 rvm:
-- "1.9"
 - "2.0"
 - "2.1"
 - "2.2.2"
@@ -12,19 +11,12 @@ before_install:
 - gem update bundler
 
 gemfile:
-- gemfiles/Gemfile.activesupport32
-- gemfiles/Gemfile.activesupport40
-- gemfiles/Gemfile.activesupport41
 - gemfiles/Gemfile.activesupport42
 - gemfiles/Gemfile.activesupport50
 - gemfiles/Gemfile.activesupport52
 
 matrix:
   exclude:
-    - rvm: "1.9"
-      gemfile: gemfiles/Gemfile.activesupport50
-    - rvm: "1.9"
-      gemfile: gemfiles/Gemfile.activesupport52
     - rvm: "2.0"
       gemfile: gemfiles/Gemfile.activesupport50
     - rvm: "2.0"

--- a/active_utils.gemspec
+++ b/active_utils.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "active_utils"
 
-  s.add_dependency('activesupport', '>= 3.2', '< 6.0')
+  s.add_dependency('activesupport', '>= 4.2', '< 6.0')
   s.add_dependency('i18n')
 
   s.add_development_dependency('rake')

--- a/active_utils.gemspec
+++ b/active_utils.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "active_utils"
 
-  s.add_dependency('activesupport', '>= 4.2', '< 6.0')
+  s.add_dependency('activesupport', '>= 4.2')
   s.add_dependency('i18n')
 
   s.add_development_dependency('rake')

--- a/gemfiles/Gemfile.activesupport-master
+++ b/gemfiles/Gemfile.activesupport-master
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+gemspec path: '..'
+
+gem 'activesupport', github: 'rails/rails'

--- a/gemfiles/Gemfile.activesupport32
+++ b/gemfiles/Gemfile.activesupport32
@@ -1,4 +1,0 @@
-source "https://rubygems.org"
-gemspec path: '..'
-
-gem 'activesupport', '~> 3.2.0'

--- a/gemfiles/Gemfile.activesupport40
+++ b/gemfiles/Gemfile.activesupport40
@@ -1,4 +1,0 @@
-source "https://rubygems.org"
-gemspec path: '..'
-
-gem 'activesupport', '~> 4.0.0'

--- a/gemfiles/Gemfile.activesupport41
+++ b/gemfiles/Gemfile.activesupport41
@@ -1,4 +1,0 @@
-source "https://rubygems.org"
-gemspec path: '..'
-
-gem 'activesupport', '~> 4.1.0'


### PR DESCRIPTION
Remove support of ActiveSupport < 4.2 and ruby 1.9:

- It's time to remove support of AS 4.2, I think we have let people
  enough time to upgrade at this point.

------------


Remove the upperbound constraint on ActiveSupport:

- Looking at this gem, there is no reason to have a upperbound
  constraint on ActiveSupport.
  It just blocks us whenever there is a new Rails upgrade.

  This commit removes the upperbound constraint and test this gem on
  the latest commig of ActiveSupport.

cc/ @Shopify/rails 