### PR TITLE
Add Vanuatu (VU) to countries without postal codes

### DIFF
--- a/lib/active_utils/country.rb
+++ b/lib/active_utils/country.rb
@@ -320,7 +320,7 @@ module ActiveUtils #:nodoc:
     COUNTRIES_THAT_DO_NOT_USE_POSTALCODES = %w(
       QA BZ BS BF BJ AG AE AI AO AW HK
       FJ ML MW JM ZW YE UG TV TT TG TD PA
-      CW GH SS BO
+      CW GH SS BO VU
     )
 
     def uses_postal_codes?

--- a/test/unit/country_test.rb
+++ b/test/unit/country_test.rb
@@ -72,7 +72,7 @@ class CountryTest < Minitest::Test
 
   def test_change_to_countries_that_do_not_use_postalcodes_is_intentional
     country_codes = Country::COUNTRIES_THAT_DO_NOT_USE_POSTALCODES
-    assert_equal(country_codes.length, 27)
+    assert_equal(country_codes.length, 28)
   end
 
   def test_canada_uses_postal_codes


### PR DESCRIPTION
As per https://github.com/Shopify/active_utils/pull/95 adds Vanuatu (VU) to list of countries not requiring postal codes.

Refs:
https://en.wikipedia.org/wiki/List_of_postal_codes - indicates no postal codes in Vanuatu
https://www.iso.org/obp/ui/#iso:code:3166:VU - ISO code confirmation
http://www.upu.int/fileadmin/documentsFiles/activities/addressingUnit/vutEn.pdf - UPU check as per previous review

Based on https://github.com/Shopify/shopify/issues/182522