### PR TITLE
Add Errno::EHOSTUNREACH to connection errors

### DIFF
--- a/lib/active_utils/network_connection_retries.rb
+++ b/lib/active_utils/network_connection_retries.rb
@@ -7,6 +7,7 @@ module ActiveUtils
       Timeout::Error         => "The connection to the remote server timed out",
       Errno::ETIMEDOUT       => "The connection to the remote server timed out",
       SocketError            => "The connection to the remote server could not be established",
+      Errno::EHOSTUNREACH    => "The connection to the remote server could not be established",
       OpenSSL::SSL::SSLError => "The SSL connection to the remote server could not be established"
     }
 

--- a/test/unit/network_connection_retries_test.rb
+++ b/test/unit/network_connection_retries_test.rb
@@ -48,13 +48,17 @@ class NetworkConnectionRetriesTest < Minitest::Test
     end
   end
 
-  def test_socket_error_raises_correctly
-    raised = assert_raises(ActiveUtils::ConnectionError) do
-      retry_exceptions do
-        raise SocketError
+  def test_connection_errors_raise_correctly
+    exceptions = [SocketError, Errno::EHOSTUNREACH]
+
+    exceptions.each do |exception|
+      raised = assert_raises(ActiveUtils::ConnectionError) do
+        retry_exceptions do
+          raise exception
+        end
       end
+      assert_equal "The connection to the remote server could not be established", raised.message
     end
-    assert_equal "The connection to the remote server could not be established", raised.message
   end
 
   def test_ssl_errors_raise_correctly


### PR DESCRIPTION
This adds Errno::EHOSTUNREACH to the list of default connection errors. This exception is occasionally raised from the Net::HTTP library and should be handled the same way as other connection errors. (This exception is already being handled in ActiveMerchant.)