### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/active_utils.gemspec
+++ b/active_utils.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{Common utils used by active_merchant, active_fulfillment, and active_shipping}
   s.license     = 'MIT'
 
-  s.rubyforge_project = "active_utils"
-
   s.add_dependency('activesupport', '>= 4.2')
   s.add_dependency('i18n')
 


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement.