### PR TITLE
Add support for PATCH HTTP method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,5 @@ matrix:
       gemfile: gemfiles/Gemfile.activesupport-master
     - rvm: "2.3"
       gemfile: gemfiles/Gemfile.activesupport-master
+    - rvm: "2.4"
+      gemfile: gemfiles/Gemfile.activesupport-master

--- a/lib/active_utils/connection.rb
+++ b/lib/active_utils/connection.rb
@@ -69,6 +69,9 @@ module ActiveUtils
             when :put
               debug body
               http.put(endpoint.request_uri, body, headers)
+            when :patch
+              debug body
+              http.patch(endpoint.request_uri, body, headers)
             when :delete
               # It's kind of ambiguous whether the RFC allows bodies
               # for DELETE requests. But Net::HTTP's delete method

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -49,6 +49,12 @@ class ConnectionTest < Minitest::Test
     assert_equal 'success', response.body
   end
 
+  def test_successful_patch_request
+    Net::HTTP.any_instance.expects(:patch).with('/tx.php', 'data', {}).returns(@ok)
+    response = @connection.request(:patch, 'data', {})
+    assert_equal 'success', response.body
+  end
+
   def test_successful_delete_request
     Net::HTTP.any_instance.expects(:delete).with('/tx.php', {}).returns(@ok)
     response = @connection.request(:delete, nil, {})


### PR DESCRIPTION
Add support for `ssl_request` with PATCH HTTP method. `patch` has been supported by `Net::HTTP` from Ruby 1.9.3 onward, so it's available on all ruby versions supported by this gem.