### PR TITLE
Add DJ, SL, TO to the COUNTRIES_THAT_DO_NOT_USE_POSTALCODES list

### DIFF
--- a/lib/active_utils/country.rb
+++ b/lib/active_utils/country.rb
@@ -320,7 +320,7 @@ module ActiveUtils #:nodoc:
     COUNTRIES_THAT_DO_NOT_USE_POSTALCODES = %w(
       QA BZ BS BF BJ AG AE AI AO AW HK
       FJ ML MW JM ZW YE UG TV TT TG TD PA
-      CW GH SS BO VU
+      CW GH SS BO VU DJ SL TO
     )
 
     def uses_postal_codes?

--- a/test/unit/country_test.rb
+++ b/test/unit/country_test.rb
@@ -72,7 +72,7 @@ class CountryTest < Minitest::Test
 
   def test_change_to_countries_that_do_not_use_postalcodes_is_intentional
     country_codes = Country::COUNTRIES_THAT_DO_NOT_USE_POSTALCODES
-    assert_equal(country_codes.length, 28)
+    assert_equal(country_codes.length, 31)
   end
 
   def test_canada_uses_postal_codes


### PR DESCRIPTION
DJ / Djibouti seems never to have implemented postal codes.  It appears that the post office has opted, instead, to standardize on using What3words to aid in sorting and delivery. Sources:
- https://www.grcdi.nl/gsb/djibouti.html
- https://www.laposte.dj/?pg=What3Words

SL / Sierra Leone has no postal codes. Sources:
- http://web.archive.org/web/20131126165352/http://salpost.sl/operational_offices.html
- https://www.grcdi.nl/gsb/sierra%20leone.html

TO / Tonga has no postal codes. Source:
- https://www.grcdi.nl/gsb/tonga.html