### PR TITLE
make posts_data honour ENV proxy settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ActiveUtils changelog
 
+### Version 3.3.19 (February 24, 2020)
+- Support `net/http` default proxy settings from `ENV['http_proxy']`
+- Support usage of custom ssl certificate with `ENV['SSL_CERT_FILE']`, default variable for Ruby
+
 ### Version 3.3.17 (February 24, 2020)
 - Add support for PATCH HTTP method in `ActiveUtils#Connection`
 

--- a/lib/active_utils/connection.rb
+++ b/lib/active_utils/connection.rb
@@ -11,9 +11,12 @@ module ActiveUtils
     OPEN_TIMEOUT = 60
     READ_TIMEOUT = 60
     VERIFY_PEER = true
-    CA_FILE = (File.dirname(__FILE__) + '/../certs/cacert.pem')
+    # allow using proxy for https calls by pointing to it's certificate
+    # SSL_CERT_FILE is variable used by Ruby to look for certificate for net/http
+    CA_FILE = ENV.fetch('SSL_CERT_FILE', File.dirname(__FILE__) + '/../certs/cacert.pem')
     CA_PATH = nil
     RETRY_SAFE = false
+    PROXY_ADDRESS = :ENV
     RUBY_184_POST_HEADERS = { "Content-Type" => "application/x-www-form-urlencoded" }
 
     attr_accessor :endpoint
@@ -45,7 +48,7 @@ module ActiveUtils
       @max_retries  = MAX_RETRIES
       @ignore_http_status = false
       @ssl_version = nil
-      @proxy_address = nil
+      @proxy_address = PROXY_ADDRESS
       @proxy_port = nil
     end
 

--- a/lib/active_utils/posts_data.rb
+++ b/lib/active_utils/posts_data.rb
@@ -24,6 +24,8 @@ module ActiveUtils #:nodoc:
       base.class_attribute :wiredump_device
 
       base.class_attribute :proxy_address
+      base.proxy_address = Connection::PROXY_ADDRESS
+
       base.class_attribute :proxy_port
     end
 

--- a/lib/active_utils/version.rb
+++ b/lib/active_utils/version.rb
@@ -1,3 +1,3 @@
 module ActiveUtils
-  VERSION = "3.3.18"
+  VERSION = "3.3.19"
 end

--- a/test/unit/posts_data_test.rb
+++ b/test/unit/posts_data_test.rb
@@ -61,4 +61,13 @@ class PostsDataTest < Minitest::Test
     assert_equal @poster.proxy_address, 'http://proxy.example.com'
     assert_equal @poster.proxy_port, '8888'
   end
+
+  class HttpConnectionAbort < StandardError; end
+
+  def test_respecting_environment_proxy_settings
+    Net::HTTP.stubs(:new).with('example.com', 80, :ENV, nil).raises(PostsDataTest::HttpConnectionAbort)
+    assert_raises(PostsDataTest::HttpConnectionAbort) do
+      @poster.ssl_post('http://example.com', '')
+    end
+  end
 end


### PR DESCRIPTION
ActiveUtils is ignoring both `ENV['http_proxy']` as well as `ENV['SSL_CERT_FILE']` which are both needed by `http/net` to correctly use local proxy settings.

`connection.proxy_settings` is always set to nil which is then passed to `net/http` and will ignore any ENV set proxy.
Setting that to `:ENV` by default will allow `net/http` to use ENV variables if this is not override. 

`SSL_CERT_FILE` is required over build in cert to use proxy client certificate when catching ssl calls

Usage of local proxy is required for some testing scenarios.

This change requires these `ENV` variables to be set and won't affect anything if they aren't 

If this is correct approach I will make same ActiveMerchant
