### PR TITLE
.github update ci.yml to use main as base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
       - '**'
   push:
     branches:
-      - master
+      - main
 jobs:
   build:
     name: Ruby ${{ matrix.version }}


### PR DESCRIPTION
Updates ci.yml to use expected default base branch now that it is `main`