### PR TITLE
Remove numeric as a required param for Country

### DIFF
--- a/lib/active_utils/country.rb
+++ b/lib/active_utils/country.rb
@@ -40,7 +40,7 @@ module ActiveUtils #:nodoc:
     attr_reader :name
 
     def initialize(options = {})
-      requires!(options, :name, :alpha2, :alpha3, :numeric)
+      requires!(options, :name, :alpha2, :alpha3)
       @name = options.delete(:name)
       @codes = options.collect{|k,v| CountryCode.new(v)}
     end

--- a/test/unit/country_test.rb
+++ b/test/unit/country_test.rb
@@ -84,4 +84,10 @@ class CountryTest < Minitest::Test
     qatar = Country.find('Qatar')
     refute qatar.uses_postal_codes?
   end
+
+  def test_find_country_without_numeric_code
+    country = Country.find('ASC')
+    assert_equal 'Ascension Island', country.to_s
+    assert_nil country.code(:numeric)
+  end
 end


### PR DESCRIPTION
In https://github.com/Shopify/active_utils/pull/123, Ascension Island and Tristan da Cunha were added to the countries list. 

These countries do not have numeric codes.
> No numeric codes for AC and TA are listed at this time, example source https://en.wikipedia.org/wiki/ISO_3166-1_numeric, so left those blank for now.

In this change, `numeric` is **removed as require param** when initializing a `Country` due to it not being present on the aforementioned countries.