### PR TITLE
Handles ENETUNREACH syscall errors (3.6.0)

### DIFF
--- a/lib/active_utils/network_connection_retries.rb
+++ b/lib/active_utils/network_connection_retries.rb
@@ -9,7 +9,8 @@ module ActiveUtils
       SocketError            => "The connection to the remote server could not be established",
       OpenSSL::SSL::SSLError => "The SSL connection to the remote server could not be established",
       Errno::EHOSTUNREACH    => "The remote server could not be reached",
-      Errno::EADDRNOTAVAIL   => "The remote server address is not available"
+      Errno::EADDRNOTAVAIL => "The remote server address is not available",
+      Errno::ENETUNREACH     => "The destination network is unreachable"
     }
 
     DEFAULT_RETRY_ERRORS = {

--- a/test/unit/network_connection_retries_test.rb
+++ b/test/unit/network_connection_retries_test.rb
@@ -50,6 +50,15 @@ class NetworkConnectionRetriesTest < Minitest::Test
     assert_equal "The remote server address is not available", raised.message
   end
 
+  def test_enetunreach_raises_correctly
+    raised = assert_raises(ActiveUtils::ConnectionError) do
+      retry_exceptions do
+        raise Errno::ENETUNREACH
+      end
+    end
+    assert_equal "The destination network is unreachable", raised.message
+  end
+
   def test_timeout_errors_raise_correctly
     exceptions = [Timeout::Error, Errno::ETIMEDOUT]
     if RUBY_VERSION >= '2.0.0'


### PR DESCRIPTION
# What?

- Catch and raise `ENETUNREACH` syscall errors as `ActiveUtils::ConnectionError`
- Release as version 3.6.0

# Why?

Resolves https://app.graphite.dev/github/pr/shop/world/177963/Fix-unhandled-Errno-ENETUNREACH-exception-in-ShippingRateProvider and similar issues

<img width="1496" height="279" alt="Screenshot 2025-09-12 at 23 18 26" src="https://github.com/user-attachments/assets/50b48c89-8709-4568-a349-f6424f67d9f1" />

[Query](https://observe.shopify.io/a/observe/investigate/query/b6a09774-5bda-4798-be2e-ff523201ef20)

## What Does `Errno::ENETUNREACH` It Mean?

> [!IMPORTANT] 
> The following explanation has been generated by Claude

`Errno::ENETUNREACH` (Network is unreachable) is a system-level error that occurs when the operating system cannot find a route to reach the destination network. This error indicates that the network layer has determined that the destination host or network cannot be reached from the current host.

## Common Conditions That Trigger ENETUNREACH

### 1. **No Route to Destination**
- The routing table doesn't contain a path to the destination network
- Default gateway is not configured or is incorrect
- Network subnet is completely isolated

### 2. **Network Interface Issues**
- Network interface is down or disabled
- Network cable is disconnected (for wired connections)  
- WiFi is disabled or not connected
- Virtual network interfaces are misconfigured

### 3. **Firewall/Security Restrictions**
- Firewall rules explicitly blocking outbound connections
- Network policies preventing access to certain IP ranges
- Security software interfering with network connectivity

### 4. **DNS Resolution to Unreachable IPs**
- Domain resolves to a private IP address from a public network
- Domain resolves to an IP in an unreachable subnet
- Stale DNS cache pointing to old, unreachable IPs

### 5. **Container/Virtualization Network Issues**
- Docker container network misconfiguration
- Kubernetes pod network policies blocking egress
- VM network adapter in wrong mode (NAT vs Bridged)
- Container trying to reach host-only networks

### 6. **VPN/Proxy Configuration**
- VPN disconnected while app expects VPN routes
- Split tunneling excluding required destinations
- Proxy server unreachable or misconfigured
- SOCKS/HTTP proxy pointing to unreachable host

### 7. **IPv4/IPv6 Conflicts**
- Application trying IPv6 when only IPv4 is available
- IPv6 enabled but not properly configured
- Dual-stack issues with preferred protocol unreachable

### 8. **Cloud/Infrastructure Specific**
- AWS Security Groups blocking outbound traffic
- Azure Network Security Groups restrictions
- GCP firewall rules preventing egress
- Kubernetes NetworkPolicy blocking pod communication
- Service mesh (Istio/Linkerd) misconfigurations

## Ruby/Rails Specific Scenarios

```ruby
# Common scenarios in Ruby applications:

# 1. HTTP requests to unreachable hosts
begin
  Net::HTTP.get(URI('http://10.0.0.1/api'))
rescue Errno::ENETUNREACH => e
  # Network to 10.0.0.1 is not routable
end

# 2. Database connections to wrong network
begin
  ActiveRecord::Base.establish_connection(
    host: '192.168.1.100',  # Private IP from wrong network
    database: 'production'
  )
rescue Errno::ENETUNREACH => e
  # Database host network unreachable
end

# 3. Redis/Memcached connections
begin
  Redis.new(host: 'cache.internal', port: 6379)
rescue Errno::ENETUNREACH => e
  # Internal network not accessible
end
```